### PR TITLE
Add missing __contains__

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,4 +10,4 @@ exclude=
   redis_shelve.egg-info/
 max-line-length = 88
 select = C,E,F,W,B,B950
-ignore = E501,W503,F811
+ignore = E203,E501,W503,F811

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,13 @@
+[flake8]
+exclude=
+  .tox
+  __pycache__
+  .pytest_cache
+  venv/
+  env/
+  _sandbox/
+  .eggs/
+  redis_shelve.egg-info/
+max-line-length = 88
+select = C,E,F,W,B,B950
+ignore = E501,W503,F811

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,20 +4,24 @@ py34:
   image: python:3.4-alpine
   stage: test
   script: 
-    - tox -e py34,flake8
+    - tox -e py34
 py35:
   image: python:3.5-alpine
   stage: test
   script: 
-    - tox -e py35,flake8
+    - tox -e py35
 py36:
   image: python:3.6-alpine
   stage: test
   script: 
-    - tox -e py36,flake8
+    - tox -e py36
 py37:
   image: python:3.7-alpine
   stage: test
   script: 
-    - tox -e py37,flake8
-  
+    - tox -e py37
+syntax:
+  image: python3.7-alpine
+  stage: syntax
+  script:
+    - tox -e syntax

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,23 @@
 dist: xenial
 language: python
-python:
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
-install:
-  - pip install -r requirements.txt
-  - pip install tox-travis
-script:
-  - tox
-  - tox -e syntax
+stages:
+  - syntax
+  - test
+jobs:
+  include:
+    - stage: syntax
+      python: "3.6"
+      install:
+        - pip install -r requirements.txt flake8 black
+      script:
+        - flake8
+        - black --check --diff .
+    - stage: test
+      python:
+        - "3.4"
+        - "3.5"
+        - "3.6"
+        - "3.7"
+      install:
+        - pip install -r requirements.txt tox-travis
+        - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,26 @@ jobs:
         - flake8
         - black --check --diff .
     - stage: test
-      python:
-        - "3.4"
-        - "3.5"
-        - "3.6"
-        - "3.7"
+      python: "3.4"
       install:
         - pip install -r requirements.txt tox-travis
+      script:
+        - python setup.py test
+    - stage: test
+      python: "3.5"
+      install:
+        - pip install -r requirements.txt tox-travis
+      script:
         - tox
+    - stage: test
+      python: "3.6"
+      install:
+        - pip install -r requirements.txt tox-travis
+      script:
+        - python setup.py test
+    - stage: test
+      python: "3.7"
+      install:
+        - pip install -r requirements.txt tox-travis
+      script:
+        - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - pip install tox-travis
 script:
   - tox
-  - tox -e flake8
+  - tox -e syntax

--- a/redisshelve/__init__.py
+++ b/redisshelve/__init__.py
@@ -15,27 +15,25 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see
 # <http://www.gnu.org/licenses/>.
-
 from shelve import Shelf
 
 
 class RedisShelf(Shelf):
     def __init__(self, redis, key_prefix=None, protocol=None, writeback=False):
-        self._prefix = '{}|'.format(key_prefix) if key_prefix else ''
-        Shelf.__init__(
-            self, dict=redis, protocol=protocol, writeback=writeback)
+        self._prefix = "{}|".format(key_prefix) if key_prefix else ""
+        Shelf.__init__(self, dict=redis, protocol=protocol, writeback=writeback)
 
     def _prefix_key(self, key):
         if not self._prefix:
             return key
-        if key.startswith('{}'.format(self._prefix)):
+        if key.startswith("{}".format(self._prefix)):
             # with writeback, shelf values are added by keys from cache.keys(),
             # but the cache keys are already prefixed.
             return key
         return "{prefix}{key}".format(prefix=self._prefix, key=key)
 
     def _remove_key_prefix(self, prefixed_key):
-        return prefixed_key[len(self._prefix):]
+        return prefixed_key[len(self._prefix) :]
 
     def __setitem__(self, key, value):
         return Shelf.__setitem__(self, self._prefix_key(key), value)
@@ -60,7 +58,7 @@ class RedisShelf(Shelf):
 
     def _redis_keys(self):
         # self.dict is actually redis.
-        return self.dict.keys(pattern='{}*'.format(self._prefix))
+        return self.dict.keys(pattern="{}*".format(self._prefix))
 
     def __iter__(self):
         for key in self._redis_keys():
@@ -74,5 +72,4 @@ class RedisShelf(Shelf):
 
 
 def open(redis, key_prefix=None, protocol=None, writeback=False):
-    return RedisShelf(
-        redis, key_prefix, protocol=protocol, writeback=writeback)
+    return RedisShelf(redis, key_prefix, protocol=protocol, writeback=writeback)

--- a/redisshelve/__init__.py
+++ b/redisshelve/__init__.py
@@ -69,6 +69,9 @@ class RedisShelf(Shelf):
             print(our_key)
             yield our_key
 
+    def __contains__(self, key):
+        return self.dict.exists(self._prefix_key(key))
+
 
 def open(redis, key_prefix=None, protocol=None, writeback=False):
     return RedisShelf(

--- a/redisshelve/__init__.py
+++ b/redisshelve/__init__.py
@@ -33,7 +33,7 @@ class RedisShelf(Shelf):
         return "{prefix}{key}".format(prefix=self._prefix, key=key)
 
     def _remove_key_prefix(self, prefixed_key):
-        return prefixed_key[len(self._prefix) :]
+        return prefixed_key[len(self._prefix):]
 
     def __setitem__(self, key, value):
         return Shelf.__setitem__(self, self._prefix_key(key), value)

--- a/redisshelve/__init__.py
+++ b/redisshelve/__init__.py
@@ -33,7 +33,7 @@ class RedisShelf(Shelf):
         return "{prefix}{key}".format(prefix=self._prefix, key=key)
 
     def _remove_key_prefix(self, prefixed_key):
-        return prefixed_key[len(self._prefix):]
+        return prefixed_key[len(self._prefix) :]
 
     def __setitem__(self, key, value):
         return Shelf.__setitem__(self, self._prefix_key(key), value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,10 +29,11 @@ omit =
     .tox/*
 
 [tox:tox]
-envlist = py34,py35,py36,py37,syntax
+envlist = py34,py35,py36,py37
 
 [testenv]
 commands = python setup.py test
+basepython = python3
 
 [testenv:syntax]
 deps = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifier =
 
 [aliases]
 test = pytest
-
 [tool:pytest]
 addopts = --verbosity=-1 --cov . --cov-branch
 
@@ -30,15 +29,17 @@ omit =
     .tox/*
 
 [tox:tox]
-envlist = py34,py35,py36,py37
+envlist = py34,py35,py36,py37,syntax
 
 [testenv]
 commands = python setup.py test
 
-[testenv:flake8]
+[testenv:syntax]
 deps = 
     flake8
-commands = flake8
+    black
+commands = 
+    black --check --diff .
 
 [testenv:py34]
 deps =

--- a/setup.py
+++ b/setup.py
@@ -24,16 +24,8 @@ with open("README.md", "r") as fh:
 setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=[
-        'redis',
-    ],
-    setup_requires=[
-        'pytest-runner',
-    ],
-    packages=['redisshelve'],
-    tests_require=[
-        'fakeredis',
-        'pytest',
-        'pytest-cov',
-    ],
+    install_requires=["redis"],
+    setup_requires=["pytest-runner"],
+    packages=["redisshelve"],
+    tests_require=["fakeredis", "pytest", "pytest-cov"],
 )

--- a/tests/test_redishelve_prefixed.py
+++ b/tests/test_redishelve_prefixed.py
@@ -15,14 +15,13 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see
 # <http://www.gnu.org/licenses/>.
-
 import pickle
-import sys
 
-import fakeredis
 import pytest
+import fakeredis
 
 import redisshelve
+
 from redisshelve import RedisShelf
 
 
@@ -35,77 +34,79 @@ def redis():
 
 @pytest.fixture
 def shelf(redis):
-    return RedisShelf(redis=redis, key_prefix='test')
+    return RedisShelf(redis=redis, key_prefix="test")
 
 
 def test_shelf_value(shelf):
     shelf.writeback = True
-    shelf['test'] = 'TEST'
-    assert 'TEST' == shelf['test']
+    shelf["test"] = "TEST"
+    assert "TEST" == shelf["test"]
 
 
 def test_shelf_get_method_returns_like_dict(shelf):
-    shelf['test'] = 'TEST'
-    assert 'TEST' == shelf.get('test')
+    shelf["test"] = "TEST"
+    assert "TEST" == shelf.get("test")
 
 
 def test_shelf_get_returns_none_as_default(shelf):
-    assert None is shelf.get('nothing')
+    assert None is shelf.get("nothing")
 
 
 def test_shelf_len(shelf):
-    shelf['one'] = 'ONE'
-    shelf['two'] = 'TWO'
+    shelf["one"] = "ONE"
+    shelf["two"] = "TWO"
 
     assert 2 == len(shelf)
 
 
 def test_shelf_iteration(shelf):
-    shelf['one'] = 'ONE'
-    shelf['two'] = 'TWO'
+    shelf["one"] = "ONE"
+    shelf["two"] = "TWO"
 
-    assert sorted(['one', 'two']) == sorted(list(shelf.keys()))
-    assert sorted(['ONE', 'TWO']) == sorted(list(shelf.values()))
+    assert sorted(["one", "two"]) == sorted(list(shelf.keys()))
+    assert sorted(["ONE", "TWO"]) == sorted(list(shelf.values()))
     actual = {}
     for k, v in shelf.items():
         actual[k] = v
-    assert {'one': 'ONE', 'two': 'TWO'} == actual
+    assert {"one": "ONE", "two": "TWO"} == actual
 
 
 def test_shelf_delete(shelf):
-    shelf['one'] = 'ONE'
-    shelf['two'] = 'TWO'
-    shelf['three'] = 'THREE'
+    shelf["one"] = "ONE"
+    shelf["two"] = "TWO"
+    shelf["three"] = "THREE"
 
-    del (shelf['two'])
+    del shelf["two"]
 
-    assert None is shelf.get('two')
+    assert None is shelf.get("two")
 
 
 def test_shelf_shelves_to_redis(shelf, redis):
-    shelf['test'] = 'TEST'
-    assert 'TEST' == pickle.loads(redis.get(b'test|test'))
+    shelf["test"] = "TEST"
+    assert "TEST" == pickle.loads(redis.get(b"test|test"))
 
 
 def test_mutable_values_with_writeback(redis):
-    shelf = RedisShelf(key_prefix='test', redis=redis, writeback=True)
+    shelf = RedisShelf(key_prefix="test", redis=redis, writeback=True)
     shelf.writeback = True
-    shelf['list'] = [1, 2, 3]
-    shelf['list'].append(4)
+    shelf["list"] = [1, 2, 3]
+    shelf["list"].append(4)
 
     # before syncing, old value is in Redis.
-    assert [1, 2, 3] == pickle.loads(redis.get(b'test|list'))
+    assert [1, 2, 3] == pickle.loads(redis.get(b"test|list"))
     shelf.sync()
-    assert [1, 2, 3, 4] == pickle.loads(redis.get(b'test|list'))
+    assert [1, 2, 3, 4] == pickle.loads(redis.get(b"test|list"))
 
 
-@pytest.mark.skipif(
-    sys.version_info.major == 3 and sys.version_info.minor < 4,
-    reason="Shelf has no context manager in Python 3.3")
+def test_contains(redis, shelf):
+    shelf["foo"] = "FOO!"
+    assert "foo" in shelf
+
+
 def test_open_as_context_manager(redis):
-    with redisshelve.open(key_prefix='test', redis=redis) as test_shelf:
-        test_shelf['test'] = 'Test 1'
-        assert 'Test 1' == test_shelf['test']
+    with redisshelve.open(key_prefix="test", redis=redis) as test_shelf:
+        test_shelf["test"] = "Test 1"
+        assert "Test 1" == test_shelf["test"]
 
     with pytest.raises(ValueError):
-        test_shelf['test']
+        test_shelf["test"]

--- a/tests/test_redishelve_unprefixed.py
+++ b/tests/test_redishelve_unprefixed.py
@@ -15,14 +15,13 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see
 # <http://www.gnu.org/licenses/>.
-
 import pickle
-import sys
 
-import fakeredis
 import pytest
+import fakeredis
 
 import redisshelve
+
 from redisshelve import RedisShelf
 
 
@@ -39,72 +38,73 @@ def shelf(redis):
 
 
 def test_shelf_value(shelf):
-    shelf['test'] = 'TEST'
-    assert 'TEST' == shelf['test']
+    shelf["test"] = "TEST"
+    assert "TEST" == shelf["test"]
 
 
 def test_shelf_get_method_returns_like_dict(shelf):
-    shelf['test'] = 'TEST'
-    assert 'TEST' == shelf.get('test')
+    shelf["test"] = "TEST"
+    assert "TEST" == shelf.get("test")
 
 
 def test_shelf_get_returns_none_as_default(shelf):
-    assert None is shelf.get('nothing')
+    assert None is shelf.get("nothing")
 
 
 def test_shelf_len(shelf):
-    shelf['one'] = 'ONE'
-    shelf['two'] = 'TWO'
+    shelf["one"] = "ONE"
+    shelf["two"] = "TWO"
 
     assert 2 == len(shelf)
 
 
 def test_shelf_iteration(shelf):
-    shelf['one'] = 'ONE'
-    shelf['two'] = 'TWO'
+    shelf["one"] = "ONE"
+    shelf["two"] = "TWO"
 
-    assert sorted(['one', 'two']) == sorted(list(shelf.keys()))
-    assert sorted(['ONE', 'TWO']) == sorted(list(shelf.values()))
+    assert sorted(["one", "two"]) == sorted(list(shelf.keys()))
+    assert sorted(["ONE", "TWO"]) == sorted(list(shelf.values()))
     actual = {}
     for k, v in shelf.items():
         actual[k] = v
-    assert {'one': 'ONE', 'two': 'TWO'} == actual
+    assert {"one": "ONE", "two": "TWO"} == actual
 
 
 def test_shelf_delete(shelf):
-    shelf['one'] = 'ONE'
-    shelf['two'] = 'TWO'
-    shelf['three'] = 'THREE'
+    shelf["one"] = "ONE"
+    shelf["two"] = "TWO"
+    shelf["three"] = "THREE"
 
-    del (shelf['two'])
+    del shelf["two"]
 
-    assert None is shelf.get('two')
+    assert None is shelf.get("two")
 
 
 def test_shelf_shelves_to_redis(shelf, redis):
-    shelf['test'] = 'TEST'
-    assert 'TEST' == pickle.loads(redis.get(b'test'))
+    shelf["test"] = "TEST"
+    assert "TEST" == pickle.loads(redis.get(b"test"))
 
 
 def test_mutable_values_with_writeback(redis):
-    shelf = RedisShelf(key_prefix='test', redis=redis, writeback=True)
-    shelf.writeback = True
-    shelf['list'] = [1, 2, 3]
-    shelf['list'].append(4)
+    shelf = RedisShelf(redis=redis, writeback=True)
+    shelf["list"] = [1, 2, 3]
+    shelf["list"].append(4)
 
     # before syncing, old value is in Redis.
-    assert [1, 2, 3] == pickle.loads(redis.get(b'test|list'))
+    assert [1, 2, 3] == pickle.loads(redis.get(b"list"))
     shelf.sync()
-    assert [1, 2, 3, 4] == pickle.loads(redis.get(b'test|list'))
+    assert [1, 2, 3, 4] == pickle.loads(redis.get(b"list"))
 
 
-@pytest.mark.skipif(
-    sys.version_info.major == 3 and sys.version_info.minor < 4,
-    reason="Shelf has no context manager in Python 3.3")
+def test_contains(redis, shelf):
+    shelf["foo"] = "FOO!"
+    assert "foo" in shelf
+
+
 def test_open_as_context_manager(redis):
-    with redisshelve.open(key_prefix='test', redis=redis) as test_shelf:
-        test_shelf['test'] = 'Test 1'
-        assert 'Test 1' == test_shelf['test']
+    with redisshelve.open(redis=redis) as test_shelf:
+        test_shelf["test"] = "Test 1"
+        assert "Test 1" == test_shelf["test"]
 
     with pytest.raises(ValueError):
-        test_shelf['test']
+        test_shelf["test"]


### PR DESCRIPTION
In order for something like this to work:
```python
import redis, redis_shelve
rd = redis.Redis()
sh = redis_shelve.Shelf(rd)

print('my_key' in sh)
```

`redis_shelve.Shelf` needs to reimplement `__contains__()`.

This PR offers an implementation
